### PR TITLE
Re-créer le cahier de positions

### DIFF
--- a/charte.tex
+++ b/charte.tex
@@ -1,30 +1,39 @@
-\documentclass[12pt]{article}
+\documentclass{article}
 
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
 \usepackage[french]{babel}
-\usepackage[top=3cm, bottom=3cm, left=3cm, right=3cm]{geometry}
-\usepackage{color}
 
-\setlength{\parindent}{0in}
+\usepackage{parskip}
 
-\newcommand{\old}[1]{\\\parbox{\textwidth}{#1}\\}
+\usepackage[
+    pdftitle={Charte de AÉDIROUM},
+    pdfauthor={AÉDIROUM},
+    bookmarks=true,
+]{hyperref}
+
+\newcommand{\article}[1]{article \ref{#1}}
+
+\title{Charte de l'AÉDIROUM}
+\date{Dernière modification~: 11 Septembre 2020}
 
 \begin{document}
-\section{Généralités}
+\maketitle
 
-\subsection{Nom et sigle}
+\section{Généralités}\label{sec:generalites}
+
+\subsection{Nom et sigle}\label{sec:nom-et-sigle}
 Association des Étudiants du Département d'Informatique et de Recherche Opérationnelle de l'Université de Montréal (AÉDIROUM)
 
-\subsection{Siège social}
+\subsection{Siège social}\label{sec:siege-social}
   \begin{description}
   \item[Adresse civique] 2920 Chemin de la Tour, Montréal, H3T 1J4, Québec, Canada, local 3190-2
   \item[Adresse postale] AÉDIROUM, Département d'Informatique et de Recherche Opérationnelle, Université de Montréal, Pavillon André-Aisenstadt, CP 6128 succ Centre-Ville, Montréal, H3C 3J7, Québec, Canada
   \end{description}
 
-\subsection{Objectifs}
+\subsection{Objectifs}\label{sec:objectifs}
 
-L'AÉDIROUM a pour but de représenter ses membres et de promouvoir leurs intérêts en tant que personnes inscrites à un programme du Département d'informatique et de recherche opérationnelle. En particulier, elle veille à :
+L'AÉDIROUM a pour but de représenter ses membres et de promouvoir leurs intérêts en tant que personnes inscrites à un programme du Département d'informatique et de recherche opérationnelle. En particulier, elle veille à~:
 \begin{itemize}
 \item favoriser l'épanouissement de chacun d'eux;
 \item promouvoir la formation et le maintien d'un niveau de vie sociale intéressant pour ses membres;
@@ -34,11 +43,11 @@ L'AÉDIROUM a pour but de représenter ses membres et de promouvoir leurs intér
 \end{itemize}
 
 
-\subsection{Sceau}
+\subsection{Sceau}\label{sec:sceau}
 Le sceau de l'association, dont la forme est déterminée par le  exécutif, ne peut être employé qu'avec le consentement du président ou du secrétaire.
 
-\subsection{Membres}
-Sont membres de l'AÉDIROUM toutes les personnes inscrites à un programme suivant à l'Université de Montréal :
+\subsection{Membres}\label{sec:membres}
+Sont membres de l'AÉDIROUM toutes les personnes inscrites à un programme suivant à l'Université de Montréal~:
 \begin{itemize}
 \item Baccalauréat spécialisé en informatique;
 \item Baccalauréat bidisciplinaire en mathématiques et informatique;
@@ -47,20 +56,18 @@ Sont membres de l'AÉDIROUM toutes les personnes inscrites à un programme suiva
 \item Doctorat en informatique.
 \end{itemize}
 
-\subsection{Droits et devoirs}
+\subsection{Droits et devoirs}\label{sec:droits-et-devoirs}
 
 Les membres ont le droit de participer à toutes les activités de l'AÉDIROUM, de recevoir les avis de convocation aux assemblées des membres, d'assister à ces assemblées et d'y voter. Ils sont éligibles comme membres du conseil exécutif et d'administration de l'AÉDIROUM.
 
 Les drois conférés à un membre sont conditionnels à ce qu'il acquitte entièrement sa cotisation
 
-\subsection{Cotisation}
+\subsection{Cotisation}\label{sec:cotisation}
 
 Les cotisations de 15\$, deux (2) fois par année (pour un total annuel de 30\$), sont perçues aux trimestres d'automne et d'hiver. Toute modification au montant ou aux dates de perception des cotisations doit être approuvée en assemblée générale. Les cotisations ne sont pas rembousables.
 
-
-
-\section{Assemblée générale des membres}
-\subsection{Convocation}
+\section{Assemblée générale des membres}\label{sec:assemblee-generale-des-membres}
+\subsection{Convocation}\label{sec:convocation-generale}
 
 Pour toute assemblée ordinaire, les membres de l'AÉDIROUM doivent être convoqués au moins cinq (5) jours ouvrables à l'avance. Les assemblées sont convoquées à l'endroit fixé par le conseil exécutif (ou par la ou les personnes qui convoquent l'assemblée).
 
@@ -72,47 +79,41 @@ En cas d'urgence ou pour tout autre cas prévu à la charte, le conseil exécuti
 
 Le conseil exécutif doit convoquer une assemblée extraordinaire si dix (10) membres l'exigent par écrit, et cela dans les dix (10) jours ouvrables suivant la réception d'une telle demande. Une telle demande doit spécifier le but et les objets d'une telle assemblée. À défaut par le conseil exécutif de convoquer telle assemblée dans le délai stipulé, celle-ci peut être convoquée par les signataires de la demande écrite eux-mêmes.
 
-\subsection{Participation}
+\subsection{Participation}\label{sec:participation}
 
 Seuls les membres ont le droit de parole et le droit de vote à une assemblée de l'AÉDIROUM. Sauf en cas de huis clos, l'assemblée demeure publique.
 
 Chaque membre de l'AÉDIROUM a droit de vote, sans prépondérance; un membre ne peut voter par procuration.
 
-\subsection{Procédure}
+\subsection{Procédure}\label{sec:procedure-generale}
 
 Après la vérification du quorum, les membres présents désignent un président et un secrétaire d'assemblée, normalement le président et le secrétaire de l'AÉDIROUM, respectivement.
 Les membres réunis peuvent adopter tout règlement concernant la procédure d'assemblée. En l'absence de règlement sur un point donné, le Guide de procédure des assemblées délibérantes de l'Université de Montréal (code de l'Espérance) s'applique.
 
-\subsection{Quorum}
+\subsection{Quorum}\label{sec:quorum}
 
- Le quorum s'établit au plus petit des deux nombres suivants : quarante (40) membres ou dix pourcents (10\%) 
-de l'effectif de l'AÉDIROUM.
+Le quorum s'établit au plus petit des deux nombres suivants~: quarante (40) membres ou dix pourcents (10\%) de l'effectif de l'AÉDIROUM.
 
-Si le quorum n’est pas atteint pour débuter deux assemblées générales consécutives, le conseil exécutif peut 
-convoquer une nouvelle assemblée générale respectant les délais de convocation dans les dix (10) jours ouvrables 
-suivants. Cette assemblée générale aura lieu, sera décisionnelle et le quorum sera atteint et maintenu sans égard 
-au nombre de membres présents, notamment en ce qui concerne l'application du paragraphe précédent.
+Si le quorum n'est pas atteint pour débuter deux assemblées générales consécutives, le conseil exécutif peut convoquer une nouvelle assemblée générale respectant les délais de convocation dans les dix (10) jours ouvrables suivants. Cette assemblée générale aura lieu, sera décisionnelle et le quorum sera atteint et maintenu sans égard au nombre de membres présents, notamment en ce qui concerne l'application du paragraphe précédent.
 
-\subsection{Élections}
-\subsubsection{Président d'élection}
+\subsection{Élections}\label{sec:elections}
+\subsubsection{Président d'élection}\label{sec:president-delection}
 
 Le président d'élection est nommé par les membres présents. Le président d'élection ne peut être candidat.
 
 Pour chaque poste soumis au suffrage, le président d'élection, s'il a droit de vote, doit consigner son vote qui ne sera dévoilé qu'en cas d'égalité.
 
-\subsubsection{Postes mis en jeu}
+\subsubsection{Postes mis en jeu}\label{sec:postes-mis-en-jeu}
 À chaque élection régulière, soit à la première assemblée générale régulière d'automne de chaque année, tous les postes du conseil exécutif sont mis en jeu, de même que ceux du conseil d'administration, incluant ceux qui ont été comblés lors d'élections spéciales.
 
-\subsubsection{Candidatures}
-
+\subsubsection{Candidatures}\label{sec:candidatures}
 Seuls les membres de l'AÉDIROUM peuvent être candidats.
 
 Toute mise en candidature doit préalablement recevoir l'assentiment du candidat.
 
-Une élection doit avoir lieu pour chaque poste en jeu même s'il n'y a qu'un candidat en lice. Les membres peuvent 
-toujours se prononcer contre l'ensemble des candidatures.
+Une élection doit avoir lieu pour chaque poste en jeu même s'il n'y a qu'un candidat en lice. Les membres peuvent toujours se prononcer contre l'ensemble des candidatures.
 
-\subsubsection{Scrutin}
+\subsubsection{Scrutin}\label{sec:scrutin-elections}
 
 L'élection a lieu tous les ans, au cours de la première assemblée générale régulière du trimestre d'automne.
 
@@ -126,44 +127,39 @@ Lors d'un scrutin secret, le président d'élections doit rejeter les bulletins 
 
 Lors d'un scrutin à main levée, le président d'élections doit s'assurer qu'aucun électeur ne vote pour plus d'un candidat et que chaque voix exprimée n'est comptée qu'une seule fois.
 
-\subsubsection{Contestation}
+\subsubsection{Contestation}\label{sec:contestation}
 
 Une élection peut être contestée s'il y a présomption d'irrégularité. Toute contestation d'élection doit être remise, par écrit, au conseil d'administration dans les deux (2) jours ouvrables suivant le jour du scrutin. La lettre de contestation doit être insérée dans le registre des procès-verbaux de l'AÉDIROUM, suivant sa date, au même titre qu'un procès-verbal régulier.
 
-\subsubsection{Élections spéciales}
+\subsubsection{Élections spéciales}\label{sec:elections-speciales}
 
   \begin{description}
-  \item[Destitution] Lorsqu'un membre du conseil exécutif est destitué par les membres réunis en assemblée générale pour les motifs énoncés à l'article 6.3, l'élection de son successeur devrait avoir lieu au cours de la même assemblée générale.
-  \item[Autre cas] Dans tout autre cas de retrait du conseil exécutif pour les raisons évoquées à l'article 6.3, une assemblée ordinaire doit être convoquée pour élire un successeur.
+  \item[Destitution] Lorsqu'un membre du conseil exécutif est destitué par les membres réunis en assemblée générale pour les motifs énoncés à l'\article{sec:scrutin}, l'élection de son successeur devrait avoir lieu au cours de la même assemblée générale.
+  \item[Autre cas] Dans tout autre cas de retrait du conseil exécutif pour les raisons évoquées à l'\article{sec:scrutin}, une assemblée ordinaire doit être convoquée pour élire un successeur.
   \item[conseil d'administration] Lorsqu'un membre du conseil d'administration est destitué ou se retire, il revient aux membres du conseil d'administration de se distribuer la tâche ou de nommer un remplaçant jusqu'à la prochaine assemblée générale.
   \item[Démission en bloc] Si le conseil exécutif ou d'administration entend démissionner en bloc, il doit annoncer clairement son intention et convoquer une assemblée générale ordinaire où seront tenues les élections rendues nécessaires.
   \end{description}
 
 
-\section{Conseil exécutif et conseil d'administration}
-\subsection{Composition du conseil exécutif}
+\section{Conseil exécutif et conseil d'administration}\label{sec:conseil-executif-et-conseil-dadministration}
+\subsection{Composition du conseil exécutif}\label{sec:composition-du-conseil-executif}
 
-Le conseil exécutif est composé de cinq (5) membres élus de l'AÉDIROUM. Ces postes sont non cumulables et définis comme suit :
+Le conseil exécutif est composé de cinq (5) membres élus de l'AÉDIROUM. Ces postes sont non cumulables et définis comme suit~:
 \begin{description}
-\item[Président] Le président est le premier officier de l'AÉDIROUM et en est le porte-parole officiel. Il coordonne le travail du conseil d'administration : il convoque ses réunions, en propose l'ordre du jour et, généralement, en préside les séances (voir l'article 3.5). Il est aussi membre d'office de tout comité de l'AÉDIROUM. Il a la charge de convoquer les assemblées générales et les réunions du conseil d'administration.
+\item[Président] Le président est le premier officier de l'AÉDIROUM et en est le porte-parole officiel. Il coordonne le travail du conseil d'administration~: il convoque ses réunions, en propose l'ordre du jour et, généralement, en préside les séances (voir l'\article{sec:adjoints}). Il est aussi membre d'office de tout comité de l'AÉDIROUM. Il a la charge de convoquer les assemblées générales et les réunions du conseil d'administration.
 \item[Vice-président interne] Le vice-président interne est responsable de tout dossier concernant les relations entre les professeurs et ses membres ou les cours auxquels ses membres assistent. Il doit consulter et informer les responsables d'année concernés lors du traitement de ces dossiers. Il est délégué d'office de l'AÉDIROUM au comité des études et à l'assemblée départementale du DIRO et au comité des affaires académiques et au comités des études supérieures de la FAÉCUM. Il remplace, en premier lieu, le président en cas d'absence ou d'incapacité de celui-ci.
 \item[Vice-président externe] Le vice-président externe assiste d'office aux réunions de tout organisme extérieur au DIRO afin d'y représenter l'AÉDIROUM, à l'exception du Conseil de la vie étudiante de la FAÉCUM. Il est délégué d'office sur le conseil d'administration de l'ADDIROUM (Association des Diplomés du Département d'Informatique et de Recherche Opérationnelle de l'Université de Montréal). Il remplace, en second lieu, le président en cas d'absence ou d'incapacité de celui-ci.
 \item[Secrétaire] Le secrétaire a la charge de conserver les documents de l'AÉDIROUM, d'en produire la déclaration annuelle de personne morale auprès de l'Inspecteur général des institutions financièse et de tenir à jour une liste des membres de l'AÉDIROUM. Il rédige les comptes-rendus des assemblées générales ainsi que ceux des réunions du conseil d'administration. Ces comptes-rendus doivent être publiés sur le site web de l'AÉDIROUM la journée de leur adoption. À l'échéance de son mandat, il doit transmettre à son successeur tous les documents dont il a la garde.
-\item[Trésorier] Le trésorier a la charge et la garde des fonds de l'AÉDIROUM et de ses livres de comptabilité. 
-Il prépare le budget annuel de l'AÉDIROUM et présente à l'assemblée générale régulière d'automne. Il prépare un 
-bilan annuel de l'AÉDIROUM et le présente a la dernière assemblée générale régulière d'hiver. Il doit également 
-faire un suivi de l'état des finances de l'AÉDIROUM lors de chaque assemblée générale ordinaire et réunion du 
-conseil d'administration. À l'échéance de son mandat, il doit transmettre à son successeur tous les documents 
-dont il a la garde. Il a la charge de remplir le rapport d'impôts de l'AÉDIROUM à la fin de chaque année fiscale.
+\item[Trésorier] Le trésorier a la charge et la garde des fonds de l'AÉDIROUM et de ses livres de comptabilité. Il prépare le budget annuel de l'AÉDIROUM et présente à l'assemblée générale régulière d'automne. Il prépare un bilan annuel de l'AÉDIROUM et le présente a la dernière assemblée générale régulière d'hiver. Il doit également faire un suivi de l'état des finances de l'AÉDIROUM lors de chaque assemblée générale ordinaire et réunion du conseil d'administration. À l'échéance de son mandat, il doit transmettre à son successeur tous les documents dont il a la garde. Il a la charge de remplir le rapport d'impôts de l'AÉDIROUM à la fin de chaque année fiscale.
 \end{description}
 
-\subsection{Fonctions du conseil exécutif}
+\subsection{Fonctions du conseil exécutif}\label{sec:fonctions-du-conseil-executif}
 
 Le conseil exécutif travaille à la réalistation des objectifs de l'AÉDIROUM et veille à l'exécution des décisions prises en assemblée générale. Il est responsable des comités de l'AÉDIROUM, et peut donc en destituer tout membre non-élu par une majorité simple. Il est responsable de la représentation de l'AÉDIROUM aux réunions du département ou de tout organisme extérieur au DIRO, incluant le choix des délégués parmi ses membres.
 
-\subsection{Composition du conseil d'administration}
+\subsection{Composition du conseil d'administration}\label{sec:composition-du-conseil-dadministration}
 
-Le conseil d'administration comprend, outre les cinq (5) membres du conseil exécutif, les membres aux postes suivants :
+Le conseil d'administration comprend, outre les cinq (5) membres du conseil exécutif, les membres aux postes suivants~:
 \begin{itemize}
 \item Représentant de première année au baccalauréat en informatique
 \item Représentant de deuxième année au baccalauréat en informatique
@@ -177,123 +173,123 @@ Le conseil d'administration comprend, outre les cinq (5) membres du conseil exé
 \item Représentant des étudiants étrangers
 \end{itemize}
 
-\subsubsection{Représentant d'année ou de programme}
+\subsubsection{Représentant d'année ou de programme}\label{sec:representant-dannee-ou-de-programme}
 
 Les représentants d'année ou de programme assurent la communication entre l'AÉDIROUM et ses membres. Ils sont responsables de contacter les membres qu'ils représentent au nom de l'AÉDIROUM et de rediriger les requêtes des membres qu'ils représentent à l'officier approprié. Ils doivent rejoindre et mobiliser les membres pour prendre part aux actions de l'AÉDIROUM. Il est à noter que les représentants d'année au baccalauréat doivent avoir au moins un cours de l'année (en informatique) qu'ils représentent lors de leur mandat; ceci est déterminé par le sigle. Les représentants des autres programmes doivent appartenir au programme qu'ils représentent.
 
-\subsubsection{Représentant des étudiants étrangers}
+\subsubsection{Représentant des étudiants étrangers}\label{sec:representant-des-etudiants-etrangers}
 
 Le représentant des étudiants étrangers assure la communication entre l'AÉDIROUM et ses membres qui ont un statut d'étudiant étranger. Il est responsable de contacter les membres qu'il représente au nom de l'AÉDIROUM et de rediriger les requêtes des membres qu'il représente à l'officier approprié. Il doit rediriger et mobiliser les membres pour prendre part aux actions de l'AÉDIROUM.
 
-\subsubsection{Coordonnateur à la vie étudiante}
+\subsubsection{Coordonnateur à la vie étudiante}\label{sec:coordonnateur-a-la-vie-etudiante}
 
- Le coordonnateur à la vie étudiante est délégué d'office aux Conseil à la Vie Étudiante de la FAÉCUM et est responsable devant le conseil d'administration de tout contact avec l'extérieur de l'AÉDIROUM concernant les activités sociales, culturelles et sportives.
-
+Le coordonnateur à la vie étudiante est délégué d'office aux Conseil à la Vie Étudiante de la FAÉCUM et est responsable devant le conseil d'administration de tout contact avec l'extérieur de l'AÉDIROUM concernant les activités sociales, culturelles et sportives.
 
 Ses autres responsabilités sont définies par le Règlement de la vie étudiante.
 
-
-\subsubsection{Représentant du café étudiant Math-Info}
+\subsubsection{Représentant du café étudiant Math-Info}\label{sec:representant-du-cafe-etudiant-math-info}
 
 La tâche du représentant du café étudiant est définie dans la charte du café. Il doit former un comité constitué de membres de l'AÉDIROUM pour remplir les postes requis par la charte du café. Il représente l'administration du café devant l'assocation et le conseil d'administration devant l'administration du café.
 
-\subsubsection{Cumul de postes}
+\subsubsection{Cumul de postes}\label{sec:cumul-de-postes}
 
-Sans aller à l'encontre de l'article 3.1, il peut y avoir, au sein du conseil d'administration, cumul de postes par une même personne.
+Sans aller à l'encontre de l'\article{sec:composition-du-conseil-executif}, il peut y avoir, au sein du conseil d'administration, cumul de postes par une même personne.
 
-\subsection{Autres membres du comité du café étudiant}
+\subsection{Autres membres du comité du café étudiant}\label{sec:autres-membres-du-comite-du-cafe-etudiant}
 
-Seront élus deux autres membres du comité du café étudiant, qui ne seront pas membres du conseil d'administration. L'un de ces postes sera ouvert en priorité à un étudiant de première année afin de favoriser le bon roulement des membres du comité du café. C'est ce poste pour lequel l'élection se fera en automne. Parmi le représentant du café étudiant et les deux membres élus du comité, deux seront signataires pour le compte du café étudiant. Pour les fins de l'article 3.7 de la présente charte, les membres du comité du café étudiant sont réputés membres du conseil d'administration.
+Seront élus deux autres membres du comité du café étudiant, qui ne seront pas membres du conseil d'administration. L'un de ces postes sera ouvert en priorité à un étudiant de première année afin de favoriser le bon roulement des membres du comité du café. C'est ce poste pour lequel l'élection se fera en automne. Parmi le représentant du café étudiant et les deux membres élus du comité, deux seront signataires pour le compte du café étudiant. Pour les fins de l'\article{sec:mandat} de la présente charte, les membres du comité du café étudiant sont réputés membres du conseil d'administration.
 
-\subsection{Adjoints}
+\subsection{Adjoints}\label{sec:adjoints}
 
-Un adjoint peut être élu en assemblée générale pour chaque poste du conseil exécutif et le CVE de l’AÉDIROUM, tels que défini à l’article 3.1. 
+Un adjoint peut être élu en assemblée générale pour chaque poste du conseil exécutif et le CVE de l'AÉDIROUM, tels que défini à l'\article{sec:composition-du-conseil-executif}.
 
-Est admissible à un poste d’adjoint tout membre en règle de l’AÉDIROUM n’occupant pas déjà un poste d’adjoint.
+Est admissible à un poste d'adjoint tout membre en règle de l'AÉDIROUM n'occupant pas déjà un poste d'adjoint.
 
-Un adjoint ne peut pas occuper de poste sur le conseil executif ou d’administration de l’AÉDIROUM.
+Un adjoint ne peut pas occuper de poste sur le conseil executif ou d'administration de l'AÉDIROUM.
 
 Un adjoint accompage le délégué aux instances de la FAÉCUM relatives au poste dont il est adjoint.
 
-La responsabilité de la formation d’un adjoint et son inclusion dans les dossiers relatifs au poste reviennent au titulaire du poste en question.
+La responsabilité de la formation d'un adjoint et son inclusion dans les dossiers relatifs au poste reviennent au titulaire du poste en question.
 
-Pour les fins de l’article 3.7 de la présente charte, les adjoints sont réputés membres du conseil d’administration.
+Pour les fins de l'\article{sec:mandat} de la présente charte, les adjoints sont réputés membres du conseil d'administration.
 
-\subsubsection{Personne de confiance}
+\subsubsection{Personne de confiance}\label{sec:personne-de-confiance}
 La personne de confiance peut être élue en assemblée générale. Elle possède les clés du local de l'association étudiante pour pouvoir y donner accès lorsque les membres du conseil exécutif ne sont pas sur les lieux.
 
-\subsection{Réunions du conseil d'administration}
-\subsubsection{Fréquence}
+\subsection{Réunions du conseil d'administration}\label{sec:reunions-du-conseil-dadministration}
+\subsubsection{Fréquence}\label{sec:frequence}
 
 Le conseil d'administration doit se réunir au moins quatre (4) fois par trimestre d'automne et d'hiver et au moins deux (2) fois par trimestre d'été.
 
-\subsubsection{Convocation}
+\subsubsection{Convocation}\label{sec:convocation-administration}
 
-Les réunions du conseil d'administration peuvent être convoquées par le président ou par le secrétaire. Elles peuvent aussi être convoquées lorsque quatre (4) membres du conseil d'administration en font une demande écrite par lettre ou par courrier électronique envoyé au président ou au secrétaire. La convocation doit avoir lieu au moins trois (3) jours ouvrables avant la réunion.\\
-Les réunions sont tenues au siège social ou tout autre lieu déterminé par le conseil exécutif et indiqué dans la convocation.\\
+Les réunions du conseil d'administration peuvent être convoquées par le président ou par le secrétaire. Elles peuvent aussi être convoquées lorsque quatre (4) membres du conseil d'administration en font une demande écrite par lettre ou par courrier électronique envoyé au président ou au secrétaire. La convocation doit avoir lieu au moins trois (3) jours ouvrables avant la réunion.
+
+Les réunions sont tenues au siège social ou tout autre lieu déterminé par le conseil exécutif et indiqué dans la convocation.
+
 Une réunion du conseil d'administration extraordinaire peut être convoquée avec 36 heures de préavis. L'ordre du jour de cette réunion ne comporte qu'un nombre très restreint de points et doit demeurer fermé.
 
-\subsubsection{Quorum et participation}
+\subsubsection{Quorum et participation}\label{sec:quorum-et-participation}
 
 Le quorum s'établit à 50\% (arrondi vers le bas) du conseil d'administration en poste et à deux (2) membres du conseil exécutif. Les décisions sont prises à la majorité simple des voix exprimées. Chaque membre du conseil d'administration a droit de vote, sans prépondérance. Les membres de l'AÉDIROUM peuvent assister, à titre d'observateurs, aux réunions du conseil d'administration.
 
-\subsubsection{Procédure}
+\subsubsection{Procédure}\label{sec:procedure-admin}
 
-Le conseil d'administration peut adopter tout règlement concernant sa procédure d'assemblée, dans la mesure où ce règlement ne contrevient pas à la charte. En l'absence de règlement sur un point donné, le Guide de procédures des assemblées délibérantes de l'Université de Montréal (code de l'Espérance) s'applique.
+Le conseil d'administration peut adopter tout règlement concernant sa procédure d'assemblée, dans la mesure où ce règlement ne contrevient pas à la charte. En l'absence de règlement sur un point donné, le Guide de procédures des assemblées délibérantes de l'Université de Montréal (code Lespérance) s'applique.
 
-\subsubsection{Président et secrétaire d'assemblée}
+\subsubsection{Président et secrétaire d'assemblée}\label{sec:president-et-secretaire-dassemblee}
 
 Les réunions du conseil exécutif sont typiquement présidées par le président de l'AÉDIROUM. Le secrétaire de l'AÉDIROUM agit typiquement comme secrétaire. Il revient aux membres du conseil d'administration de choisir parmi eux un président et un secrétaire d'assemblée au début de chaque réunion.
 
-\subsubsection{Résolution signée}
+\subsubsection{Résolution signée}\label{sec:resolution-signee}
 
 Une résolution écrite, signée par tous les membres du conseil exécutif et une majorité simple du conseil adminsitratif, est valide et a le même effet que si elle avait été adoptée à une réunion du conseil d'administration dûment convoquée et tenue. Une telle résolution doit être insérée dans le registre des procès-verbaux de l'AÉDIROUM, suivant sa date, au même titre qu'un procès-verbal régulier.
 
-\subsection{Mandat}
+\subsection{Mandat}\label{sec:mandat}
 Le mandat des membres du conseil exécutif ou du conseil d'administration débute dès leur élection et se termine au plus tard à l'élection de leur successeur.
 
 Le membre devra retourner l'ensemble des clés qui lui a été fourni le jour même de la fin de son mandat.
 
-\subsection{Destitution, démission et retrait d'un membre du conseil exécutif ou du conseil d'administration}
-\subsubsection{Destitution}
+\subsection{Destitution, démission et retrait d'un membre du conseil exécutif ou du conseil d'administration}\label{sec:destitution-demission-retrait-exec-admin}
+\subsubsection{Destitution}\label{sec:destitution}
 
-Peut être destitué tout membre du conseil exécutif ou du conseil d'administration qui a une conduite contraire aux intérêts de l'AÉDIROUM ou qui n'en respecte pas les statuts. Une telle destitution prend effet immédiatement et doit être approuvée par les deux tiers (2/3) (arrondi vers le haut) des membres présents à une assemblée générale extraordinaire convoquée dans les plus brefs délais, selon les règles édictées à l'article 2.1.
+Peut être destitué tout membre du conseil exécutif ou du conseil d'administration qui a une conduite contraire aux intérêts de l'AÉDIROUM ou qui n'en respecte pas les statuts. Une telle destitution prend effet immédiatement et doit être approuvée par les deux tiers (\( \frac{2}{3} \)) (arrondi vers le haut) des membres présents à une assemblée générale extraordinaire convoquée dans les plus brefs délais, selon les règles édictées à l'\article{sec:convocation-generale}.
 
-\subsubsection{Destitution pour absence}
+\subsubsection{Destitution pour absence}\label{sec:destitution-pour-absence}
 
-Par ailleurs le conseil exécutif peut destituer un de ses membres ou un membre du conseil d'administration s'il est absent sans motif lors de trois (3) réunions consécutives. S'il s'agit d'un membre du conseil exécutif, une assemblée générale extraordinaire doit alors être convoquée dans les plus brefs délais (voir article 2.1). Le mem
-bre destitué peut appeler de la décision du conseil exécutif au cours de cette assemblée où les membres présents doivent approuver la décision par un vote à majorité aux deux tiers (2/3) (arrondi vers le haut).
+Par ailleurs le conseil exécutif peut destituer un de ses membres ou un membre du conseil d'administration s'il est absent sans motif lors de trois (3) réunions consécutives. S'il s'agit d'un membre du conseil exécutif, une assemblée générale extraordinaire doit alors être convoquée dans les plus brefs délais (voir l'\article{sec:convocation-generale}). Le mem
+bre destitué peut appeler de la décision du conseil exécutif au cours de cette assemblée où les membres présents doivent approuver la décision par un vote à majorité aux deux tiers (\( \frac{2}{3} \)) (arrondi vers le haut).
 
-\subsubsection{Retrait d'un membre du conseil exécutif ou du conseil d'administration}
+\subsubsection{Retrait d'un membre du conseil exécutif ou du conseil d'administration}\label{sec:retrait-dun-membre-exec-admin}
 
-Cesse de faire partie du conseil exécutif ou du conseil d'administration et d'occuper sa fonction tout membre qui se trouve dans l'une des situations suivantes :
+Cesse de faire partie du conseil exécutif ou du conseil d'administration et d'occuper sa fonction tout membre qui se trouve dans l'une des situations suivantes~:
   \begin{itemize}
   \item il présente par écrit sa démission au conseil exécutif;
   \item il décède, devient insolvable ou incapable, est accusé d'un acte criminel selon le droit canadien;
-  \item il est destitué suivant l'une des procédures décrites par les articles 3.7.1 et 3.7.2.
+  \item il est destitué suivant l'une des procédures décrites par l'\article{sec:mandat}.
   \end{itemize}
 
-\subsection{Rémunération}
+\subsection{Rémunération}\label{sec:renumeration}
 
 Aucun des membres du conseil d'administration n'est rémunéré pour l'exercice de ses fonctions. Ils ne peuvent pas non plus tirer profit financier d'activités faites au nom de l'AÉDIROUM.
 
-\subsection{Indemnisation}
+\subsection{Indemnisation}\label{sec:indemnisation}
 
-Tout membre du conseil exécutif, ses héritiers et ayants droit seront tenus, au besoin et à toute époque, à même les fonds de l'AÉDIROUM, indemnes et à couvert :
+Tout membre du conseil exécutif, ses héritiers et ayants droit seront tenus, au besoin et à toute époque, à même les fonds de l'AÉDIROUM, indemnes et à couvert~:
 \begin{itemize}
 \item de tous frais, charges et dépenses quelconques que ce membre subit ou supporte au cours ou à l'occasion d'une action, poursuite ou procédure intenté contre lui, à l'égard ou en raison d'actes faits ou choses accomplies ou permises par lui dans l'exercice ou pour l'exécution de ses fonctions, et
 \item de tous autres frais, charges et dépenses qu'il supporte ou subit au cours ou à l'occation des affaires de l'AÉDIROUM ou relativement à ces affaires, exceptés ceux qui résultent de sa propre néglicence ou de son omission volontaire.
 \end{itemize}
 
-\subsubsection{Procédure de preuve}
+\subsubsection{Procédure de preuve}\label{sec:procedure-de-preuve}
 
 Afin qu'un membre du conseil d'administration, ses héritiers et ayants droits puissent se prévaloir des dispositions d'indemnisation, les factures originales doivent être présentées au trésorier de l'AÉDIROUM.
 
-\subsection{Vacance}
+\subsection{Vacance}\label{sec:vacance}
 
 Si un poste du conseil exécutif est vacant, la charge vacante est redistribuée entre les autres membres du conseil exécutif jusqu'à élection d'un remplaçant.
 
-\section{Comités}
+\section{Comités}\label{sec:comites}
 
 Le conseil d'administration ou les membres réunis en assemblée peuvent mettre sur pied tout comité jugé utile à la bonne marche de l'AÉDIROUM.
 
@@ -301,66 +297,63 @@ Lors de la mise sur pied du comité, la nature de son mandat ainsi que sa durée
 
 Un président doit aussi être nommé et choisi par le conseil d'administration parmi les membres de l'AÉDIROUM. À la demande du conseil d'administration, le président d'un comité doit faire un rapport oral au conseil d'administration. À la fin du mandat, les activités du comité doivent cesser et le président du comité doit alors présenter, lors de la prochaine assemblée générale des membres, un rapport écrit du bilan du comité.
 
-\section{Modification à la charte}
+\section{Modification à la charte}\label{sec:modification-a-la-charte}
 
-Tout amendement à la présente charte doit être proposé lors d'une assemblée générale et adopté aux deux tiers (2/3) (arrondi vers le haut) des voix exprimées. Les changements proposés doivent être rendus disponibles dans l'avis de convocation.
+Tout amendement à la présente charte doit être proposé lors d'une assemblée générale et adopté aux deux tiers (\( \frac{2}{3} \)) (arrondi vers le haut) des voix exprimées. Les changements proposés doivent être rendus disponibles dans l'avis de convocation.
 
-\section{Référendums}
-\subsection{Tenue d'un référendum}
+\section{Référendums}\label{sec:referendums}
+\subsection{Tenue d'un référendum}\label{sec:tenue-dun-referendum}
 Les membres de l'AÉDIROUM réunis en assemblée générale peuvent décréter la tenue d'un référendum et décider de sa date et du libellé de ses questions ou propositions, de même que d'un taux de participation minimal.
 
 Le conseil exécutif peut également décider de tenir un référendum. Il décide alors de sa date et du libellé de ses questions ou propositions. Un tel référendum n'est valide que si le taux de participation atteint au moins 20\% (arrondi vers le bas) des membres.
 
 Un référendum n'est ni un sondage ni un plébiscite; la décision résultante, si applicable devient une position officielle de l'AÉDIROUM.
 
-\subsection{Président de référendum}
-
+\subsection{Président de référendum}\label{sec:president-de-referendum}
 Le président de référendum est nommé par le conseil exécutif. Pour chaque question ou proposition soumise au suffrage, le président, s'il a droit de vote, doit consigner son vote qui ne sera comptabilité qu'en cas d'égalité.
 
-\subsection{Scrutin}
-\subsubsection{Modalités}
+\subsection{Scrutin}\label{sec:scrutin}
+\subsubsection{Modalités}\label{sec:modalites-scrutin}
 
 Un référendum se tient sur une période d'au moins trois (3) jours ouvrables. Durant cette période, le bureau de scrutin doit être ouvert aux membres à des heures raisonnables et en un endroit fréquenté par ses membres. Le vote est secret.
 
-\subsubsection{Droit de vote}
+\subsubsection{Droit de vote}\label{sec:droit-de-vote}
 
 Tous les membres de l'AÉDIROUM ont droit de vote. Cependant, le vote du président d'élection, si applicable, demeure secret et sans effet dans les cas où une option obtient la majorité des votes exprimés; son vote n'est comptabilisé qu'en cas d'égalité.
 
-\subsubsection{Modalités de la convocation}
+\subsubsection{Modalités de la convocation}\label{sec:modalites-convocation}
 
 La date et le lieu d'un référendum, de même que le libellé des qusetions ou des propositions soumises, doivent être publiés dix (10) jours ouvrables avant la période de scrutin.
 
-\section{Cahier de positions}
+\section{Cahier de positions}\label{sec:cahier-de-positions}
 
-\subsection{Contenu}
+\subsection{Contenu}\label{sec:contenu-positions}
 
-Le cahier de positions de l’AÉDIROUM contient toutes les positions ainsi que toutes les motions présentement en vigeur adoptées en assemblée générale des membres de l’AÉDIROUM ou en conseil d’administration.
+Le cahier de positions de l'AÉDIROUM contient toutes les positions ainsi que toutes les motions présentement en vigeur adoptées en assemblée générale des membres de l'AÉDIROUM ou en conseil d'administration.
 
-L’instance de l’adoption ainsi que l’historique des modifications de chaque élément du cahier de positions doit figurer après cet élément.
+L'instance de l'adoption ainsi que l'historique des modifications de chaque élément du cahier de positions doit figurer après cet élément.
 
-Une position ou motion adoptée en assemblée générale de l’AÉDIROUM ne peut être modifiée qu’en assemblée générale des membres de l’AÉDIROUM.
+Une position ou motion adoptée en assemblée générale de l'AÉDIROUM ne peut être modifiée qu'en assemblée générale des membres de l'AÉDIROUM.
 
-\subsection{Mise à jour}
+\subsection{Mise à jour}\label{sec:mise-a-jour-positions}
 
-Le cahier de positions doit être mis à jour par le secrétaire de l’AÉDIROUM dans les cinq jours ouvrables suivant l’adoption, la modification, ou le retrait de positions ou de motions.
+Le cahier de positions doit être mis à jour par le secrétaire de l'AÉDIROUM dans les cinq jours ouvrables suivant l'adoption, la modification, ou le retrait de positions ou de motions.
 
 Le cahier de positions mis à jour doit être rendu public dans les plus brefs délais. Une annonce aux membres doit suivre la publication de toute version du cahier de positions.
 
-\subsection{Effet}
+\subsection{Effet}\label{sec:effet-positions}
 
-Le conseil exécutif et d’administration de l’AÉDIROUM se doit de respecter les positions et motions contenues dans le cahier des position.
+Le conseil exécutif et d'administration de l'AÉDIROUM se doit de respecter les positions et motions contenues dans le cahier des position.
 
-Cependant, en l’absence d’une position contraire, un membre du conseil exécutif ou d’administration de l’AÉDIROUM peut toujours agir afin de défendre les intérêts des membres de l’AÉDIROUM.
+Cependant, en l'absence d'une position contraire, un membre du conseil exécutif ou d'administration de l'AÉDIROUM peut toujours agir afin de défendre les intérêts des membres de l'AÉDIROUM.
 
-\section{Hiérarchie des délégués à la FAÉCUM}
+\section{Hiérarchie des délégués à la FAÉCUM}\label{sec:hierarchie-delegues-faecum}
 
 Les articles qui suivent demeurent en application tant que l'AÉDIROUM reste affiliée à la FAÉCUM.
 
-\subsection{Délégué au conseil central de la FAÉCUM}
+\subsection{Délégué au conseil central de la FAÉCUM}\label{sec:delegue-conseil-central}
 
-Le représentant officiel de l'AÉDIROUM à une instance ou sous-instance est la personne présente à celle-ci qui est la plus haute dans la hiérarchie suivante. Le délégué d’office à l’instance ou la sous-instance est la personne spécifiée dans la charte. Si la personne la plus haute
-dans la hiérarchie ne peut se présenter à l’instance, il revient au prochain dans la
-hiérarchie de remplir ce rôle si possible.
+Le représentant officiel de l'AÉDIROUM à une instance ou sous-instance est la personne présente à celle-ci qui est la plus haute dans la hiérarchie suivante. Le délégué d'office à l'instance ou la sous-instance est la personne spécifiée dans la charte. Si la personne la plus haute dans la hiérarchie ne peut se présenter à l'instance, il revient au prochain dans la hiérarchie de remplir ce rôle si possible.
   \begin{enumerate}\setcounter{enumi}{-1}
   \item délégué d'office à l'instance,
   \item président,
@@ -372,43 +365,42 @@ hiérarchie de remplir ce rôle si possible.
   \item tout membre de l'AÉDIROUM, sous l'approbation d'un membre du conseil exécutif.
   \end{enumerate}
 
-\subsection{Délégués au congrès de la FAÉCUM}
-
+\subsection{Délégués au congrès de la FAÉCUM}\label{sec:delegues-congres}
 Les délégués de l'AÉDIROUM au congrès de la FAÉCUM sont choisis par le conseil exécutif parmi les membres du conseil exécutif. Pour compléter la délégation, s'il y a lieu, le conseil exécutif nomme ses autres représentants, si possible parmi les membres du conseil d'administration.
 
-\subsection{Délégués d'office aux instances et sous-instances de la FAÉCUM}
+\subsection{Délégués d'office aux instances et sous-instances de la FAÉCUM}\label{sec:delegues-doffice-instances}
 \begin{description}
-\item[Congrès] : Vice-président externe
-\item[Conseil Central (CC)] : Vice-président externe
-\item[Conseil des affaires académiques (CAA)] : Vice-président interne, il devrait y avoir un membre du 1er cycle dans la délégation du CAA. Dans la mesure du possible.
-\item[Conseil des études supérieures (CES)] : Vice-président interne, il devrait y avoir un membre des 2e ou 3e cycles dans la délégation du CES. Dans la mesure du possible.
-\item[Conseil des affaires socio-politiques (CASP)] : Vice-président externe
-\item[Conseil à la Vie Étudiante (CVE)] : Coordonnateur à la vie étudiante
+\item[Congrès]~: Vice-président externe
+\item[Conseil Central (CC)]~: Vice-président externe
+\item[Conseil des affaires académiques (CAA)]~: Vice-président interne, il devrait y avoir un membre du 1er cycle dans la délégation du CAA. Dans la mesure du possible.
+\item[Conseil des études supérieures (CES)]~: Vice-président interne, il devrait y avoir un membre des 2e ou 3e cycles dans la délégation du CES. Dans la mesure du possible.
+\item[Conseil des affaires socio-politiques (CASP)]~: Vice-président externe
+\item[Conseil à la Vie Étudiante (CVE)]~: Coordonnateur à la vie étudiante
 \end{description}
 
-\section{Dispositions financières}
-\subsection{Année financière}
+\section{Dispositions financières}\label{sec:dispositions-financieres}
+\subsection{Année financière}\label{sec:annee-financiere}
 
 L'exercice financier de l'AÉDIROUM se termine le 31 août de chaque année, ou à toute autre date qu'il plaira au conseil exécutif de fixer.
 
-\subsection{Créance}
+\subsection{Créance}\label{sec:creance}
 
 L'AÉDIROUM ne fait crédit à aucune personne, physique ou morale, sauf en cas de dépôt requis pour les biens ou services qu'elle se procure. Le conseil exécutif a la charge commune de récupérer rapidement toute somme qui lui est due ou qui est perçue en son nom.
 
-\section{Effets bancaires et contrats}
-\subsection{Signataires}
+\section{Effets bancaires et contrats}\label{sec:effets-bancaires-contrats}
+\subsection{Signataires}\label{sec:signataires}
 Les cinq (5) signataires de l'AÉDIROUM sont changés après chaque élection régulière en automne ou au besoin lorsque les membres du conseil exécutif ne sont plus les mêmes. Les signataires sont les (5) membres du conseil exécutif.
 
-\subsection{Effets bancaires}
+\subsection{Effets bancaires}\label{sec:effets-bancaires}
 
 Tous les chèques et autres effets bancaires de l'AÉDIROUM doivent être signés par deux (2) membres du conseil exécutif ou toutes autres personnes désignées par le conseil exécutif. Un signataire ne peut signer un chèque pour lui-même.
 
-\subsection{Contrats}
+\subsection{Contrats}\label{sec:contrats}
 
 Les contrats et autres documents requérant la signature de l'AÉDIROUM sont au préalable approuvés (à majorité simple) par le conseil exécutif et, sur telle approbation, sont signés par deux (2) membres du conseil exécutif ou toutes autres personnes désignées par le conseil exécutif pour les besoins d'un contrat ou d'un document particulier. Une même personne ne peut pas signer pour deux parties différentes sur un contrat.
 
-\section{Version de la charte}
+\section{Version de la charte}\label{sec:version-de-la-charte}
 La présente version de la charte remplace, depuis son adpotion par l'assemblée générale, toutes les versions antérieures. Cette charte peut être remplacée par toute version ultérieure dès l'adoption de cette dernière en assemblée générale.
 
-Date de l'adoption de cette charte : 23 septembre 2016.
+Date de l'adoption de cette charte~: 23 septembre 2016.
 \end{document}

--- a/charte.tex
+++ b/charte.tex
@@ -219,6 +219,9 @@ La responsabilité de la formation d’un adjoint et son inclusion dans les doss
 
 Pour les fins de l’article 3.7 de la présente charte, les adjoints sont réputés membres du conseil d’administration.
 
+\subsubsection{Personne de confiance}
+La personne de confiance peut être élue en assemblée générale. Elle possède les clés du local de l'association étudiante pour pouvoir y donner accès lorsque les membres du conseil exécutif ne sont pas sur les lieux.
+
 \subsection{Réunions du conseil d'administration}
 \subsubsection{Fréquence}
 

--- a/positions.tex
+++ b/positions.tex
@@ -50,9 +50,19 @@ Ce document a été créé à la session d'hiver 2011 par l'exécutif en place a
 			Adopté: [AG-14/09/2011]
 		\end{instance}
 
-	\item \marginnote{Mode de scrutin} Que l'AÉDIROUM soutienne la cause du SENSÉ dans ses démarches pour un nouveau mode de scrutin à mi-chemin entre la représentation circonscriptions et le vote proportionnel mixte. Ce mode permet aux partis politiques émergents d'être moins pénalisés par le système de circonscriptions et surtout de donner un pourcentage de pouvoir à chaque parti qui correspond au pourcentage réel de la population derrière chaque parti.
+	\item \marginnote{Discrimination} Que l'AÉDIROUM se positionne contre le sexisme, l'homophobie, la transphobie, l'hétéronormativité et toutes formes de discrimination basées sur le sexe, le genre ou l'orientation sexuelle. Que l'AÉDIROUM prenne acte des inégalités persistantes entre les hommes et les femmes et qu'elle s'oppose à leurs perpétuations.
 		\begin{instance}
-			Adopté: [AG-04/04/2018]
+			Adopté: [AG-26/11/2013]
+		\end{instance}
+
+	\item \marginnote{Démocracie} Que l'AÉDIROUM appuie le principe de démocratisation des institutions d'enseignement dans une perspective d'autogestion. Que l'AÉDIROUM se positionne pour l'élection du conseil d'administration et du rectorat de l'Université de Montréal par la communauté universitaire.
+		\begin{instance}
+			Adopté: [AG-26/11/2013]
+		\end{instance}
+
+	\item \marginnote{Féderations} Que l'AÉDIROUM se positionne contre l'adhésion de la FAÉCUM à une ou toutes fédérations étudiantes pancanadiennes.
+		\begin{instance}
+			Adopté: [AG-26/11/2013]
 		\end{instance}
 
 	\item \marginnote{Aide financière} Que l'AÉDIROUM soit pour un régime d'aide financière adéquat ayant pour but d'éliminer l'endettement étudiant et d'assurer la satisfaction des besoins fondamentaux.
@@ -90,6 +100,11 @@ Ce document a été créé à la session d'hiver 2011 par l'exécutif en place a
 		\end{enumerate}
 		\begin{instance}
 			Adopté: [AG-14/02/2014]
+		\end{instance}
+
+	\item \marginnote{Mode de scrutin} Que l'AÉDIROUM soutienne la cause du SENSÉ dans ses démarches pour un nouveau mode de scrutin à mi-chemin entre la représentation circonscriptions et le vote proportionnel mixte. Ce mode permet aux partis politiques émergents d'être moins pénalisés par le système de circonscriptions et surtout de donner un pourcentage de pouvoir à chaque parti qui correspond au pourcentage réel de la population derrière chaque parti.
+		\begin{instance}
+			Adopté: [AG-04/04/2018]
 		\end{instance}
 \end{enumerate}
 

--- a/positions.tex
+++ b/positions.tex
@@ -1,140 +1,129 @@
-\documentclass[12pt]{article} \usepackage[french]{babel}
-\usepackage[latin1]{inputenc} \usepackage[T1]{fontenc}
-\usepackage{amsmath} \usepackage{amssymb} \usepackage{amsthm}
-\usepackage{verbatim} \usepackage{graphicx} \usepackage{ulem}
-
-\setlength\parindent{0cm}
-\setlength{\parskip}{0.3cm}
+\documentclass[twoside]{article}
+\usepackage[french]{babel}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{marginnote}
 
 \newenvironment{instance}
-{\flushright \scriptsize}
+{\flushright\itshape\scriptsize}
 
-\title{Cahier de positions de l'AÉDIROUM}
+\title{Cahier de positions}
+\author{AÃ‰DIROUM}
+\date{Ã€ jour du \today}
 
 \begin{document}
 
 \maketitle
 
-Le présent document regroupe l'ensemble des positions de
-l'AÉDIROUM. Il est utilisé par toute personne faisant de la
-représentation au nom de l'association étudiante. Ce document doit
-être mis à jour régulièrement afin de bien refléter les positions des
-membres de l'AÉDIROUM.
+Le prÃ©sent document regroupe l'ensemble des positions de l'AÃ‰DIROUM. Il est utilisÃ© par toute personne faisant de la reprÃ©sentation au nom de l'association Ã©tudiante. Ce document doit Ãªtre mis Ã  jour rÃ©guliÃ¨rement afin de bien reflÃ©ter les positions des membres de l'AÃ‰DIROUM.
 
-Ce document a été créé à la session d'hiver 2011 par l'exécutif en
-place afin de recenser les opinions de ses membres. Les positions sont
-organisées en deux sections selon leur champ d'application.
+Ce document a Ã©tÃ© crÃ©Ã© Ã  la session d'hiver 2011 par l'exÃ©cutif en place afin de recenser les opinions de ses membres, abrogÃ© en 2016, puis reconstituÃ© en 2021. Les positions sont organisÃ©es en deux sections selon leur champ d'application.
 
-\section*{Affaires externes}
+\section{Affaires externes}
+\begin{enumerate}
+	\item \marginnote{Frais de scolaritÃ©} Que l'AÃ‰DIROUM travaille afin que le systÃ¨me d'Ã©ducation supÃ©rieure quÃ©bÃ©cois:
+		\begin{itemize}
+			\item Soit Ã©galement accessible indÃ©pendamment de la situation financiÃ¨re des Ã©tudiants et de leurs proches;
+			\item Permette Ã  un maximum d'Ã©tudiants compÃ©tents de complÃ©ter leurs projets d'Ã©tudes et d'emploi.
+		\end{itemize}
+		\begin{instance}
+			AdoptÃ©: [AG-02/11/2011]
+		\end{instance}
 
-\subsection*{Frais de scolarité}
+	\item Que l'AÃ‰DIROUM s'oppose Ã  toute hausse des frais de scolaritÃ©, en perspective de la gratuitÃ© scolaire.
+		\begin{instance}
+			AdoptÃ©: [AG-07/04/2011], ModifiÃ©: [AG-10/02/2012], ModifiÃ©: [AG-16/03/2012]
+		\end{instance}
 
-Que l'AÉDIROUM travaille afin que le système d'éducation supérieure
-québécois:
-\begin{itemize}
-\item Soit également accessible indépendamment de la situation financière des étudiants et de leurs proches;
-\item Permette à un maximum d'étudiants compétents de compléter leurs
-  projets d'études et d'emploi.
-\end{itemize}
+	\item \marginnote{Environnement} Que l'AÃ‰DIROUM mette de l'avant et dÃ©fende les initiatives environnementales.
+		\begin{instance}
+			AdoptÃ©: [AG-25/01/2011]
+		\end{instance}
 
-\begin{instance}
-  \emph{Adopté: [AG-02/11/2011]}
-\end{instance}
+	\item \marginnote{Transport en commun} Que l'AÃ‰DIROUM appuie des dÃ©marches en vue d'avoir un tarif rÃ©duit pour tous les Ã©tudiants Ã  temps plein.
+		\begin{instance}
+			AdoptÃ©: [AG-07/04/2011], ModifiÃ©: [AG-14/09/2011]
+		\end{instance}
 
+	\item \marginnote{AccÃ¨s Ã  l'information} Que la FAÃ‰CUM facilite l'accÃ¨s Ã  ses documents, notamment en permettant de rendre public ses documents d'intÃ©rÃªt gÃ©nÃ©ral, dont ses rÃ¨glements gÃ©nÃ©raux et sa politique d'accÃ¨s Ã  l'information.
+		\begin{instance}
+			AdoptÃ©: [AG-14/09/2011]
+		\end{instance}
 
-% Considérant la hausse des frais de scolarités de 500\$ infligés aux
-% étudiants en 2007, une hausse de 30\%, et considérant qu'une nouvelle
-% hausse de 1625\$ est annoncée pour 2012, une hausse de 75\%, les
-% étudiants d'informatique de l'Université de Montréal exigent que
-% l'état Québécois cesse toute hausse de la contribution étudiante au
-% système universitaire.
+	\item \marginnote{Mode de scrutin} Que l'AÃ‰DIROUM soutienne la cause du SENSÃ‰ dans ses dÃ©marches pour un nouveau mode de scrutin Ã  mi-chemin entre la reprÃ©sentation circonscriptions et le vote proportionnel mixte. Ce mode permet aux partis politiques Ã©mergents d'Ãªtre moins pÃ©nalisÃ©s par le systÃ¨me de circonscriptions et surtout de donner un pourcentage de pouvoir Ã  chaque parti qui correspond au pourcentage rÃ©el de la population derriÃ¨re chaque parti.
+		\begin{instance}
+			AdoptÃ©: [AG-04/04/2018]
+		\end{instance}
 
-Que l'AÉDIROUM s'oppose à toute hausse des frais de scolarité, en
-perspective de la gratuité scolaire.
-\begin{instance}
-  \emph{Adopté: [AG-07/04/2011], Modifié: [AG-10/02/2012], Modifié:
-    [AG-16/03/2012]}
-\end{instance}
+	\item \marginnote{Aide financiÃ¨re} Que l'AÃ‰DIROUM soit pour un rÃ©gime d'aide financiÃ¨re adÃ©quat ayant pour but d'Ã©liminer l'endettement Ã©tudiant et d'assurer la satisfaction des besoins fondamentaux.
+		\begin{instance}
+			AdoptÃ©: [AG-14/02/2014]
+		\end{instance}
 
-\sout{Que l'AÉDIROUM promeuve le rétablissement du gel des frais de
-scolarité pour le Québec.}
+	\item \marginnote{Entreprises privÃ©es} Que l'AÃ‰DIROUM soit pour un rÃ©seau d'Ã©ducation public libre de toute ingÃ©rence de l'entreprise privÃ©e au niveau de la gouvernance des institutions publiques, et que l'AÃ‰DIROUM condamne la culture de sous-traitance abusive dans les institutions publiques d'Ã©ducation.
+		\begin{instance}
+			AdoptÃ©: [AG-14/02/2014]
+		\end{instance}
 
-\begin{instance}
-  \emph{Adopté: [AG-25/01/2011], Abrogé: [AG-07/04/2011]}
-\end{instance}
+	\item Que l'AÃ‰DIROUM soit contre toute forme de mondialisation qui entÃ©rine la prÃ©dominance du profit sur le bien-Ãªtre de la population.
+		\begin{instance}
+			AdoptÃ©: [AG-14/02/2014]
+		\end{instance}
 
-% Considérant que les frais institutionnels obligatoires (FIO) ne sont
-% régis que par un règlement qui peut être modifié par seul décrêt
-% ministériel; considérant que les étudiants de l'Université de Montréal
-% ont été chargés trop de FIO pendant les sessions [insert sessions];
-% les étudiants d'informatique de l'Université de Montréal demandent
-% l'établissement d'une loi cadre sur les FIO.
+	\item \marginnote{InclusivitÃ©} Que l'AÃ‰DIROUM dÃ©nonce toute forme de discrimination ciblant l'identitÃ© ou l'expression de genre.
+		\begin{instance}
+			AdoptÃ©: [AG-14/02/2014]
+		\end{instance}
 
-% Que le gouvernement établisse une loi encadrant les frais
-% institutionnels obligatoires.
+	\item Que l'AÃ‰DIROUM appuie le Groupe d'action trans* de l'UniversitÃ© de MontrÃ©al dans ses dÃ©marches pour une universitÃ© inclusive.
+		\begin{instance}
+			AdoptÃ©: [AG-14/02/2014]
+		\end{instance}
 
-\subsection*{Environnement} Que l'AÉDIROUM mette de l'avant et défende
-les initiatives environnementales.
-\begin{instance}
-  \emph{Adopté: [AG-25/01/2011]}
-\end{instance}
+	\item Que l'AÃ‰DIROUM invite l'UniversitÃ© de MontrÃ©al~:
+		\begin{enumerate}
+			\item Ã  modifier sa Politique contre le harcÃ¨lement afin d'interdire explicitement la discrimination envers l'identitÃ© ou l'expression de genre, et Ã  promouvoir l'acceptation des personnes trans*~;
+			\item Ã  faciliter les dÃ©marches permettant de concilier l'identitÃ© de genre des Ã©tudiants et leur statut administratif, notamment en permettant aux Ã©tudiants d'utiliser leur nom, leur formule d'appel et leur mention de sexe prÃ©fÃ©rÃ©s sur leur carte Ã©tudiante, sur leur horaire, sur les listes de classe, sur l'environnement StudiUM, dans leur courriel institutionnel, et dans tout autre contexte oÃ¹ il est possible de le faire~;
+			\item Ã  crÃ©er des espaces plus accessibles pour les personnes trans*, notamment en incluant des toilettes neutres sur ses plans de construction ou de rÃ©novation futurs ou en affichant les toilettes Ã  une place comme neutres~;
+			\item Ã  faciliter, dans la mesure du possible, l'accÃ¨s aux soins de santÃ© que requiÃ¨rent les personnes trans* Ã  la clinique universitaire, et Ã  Ã©duquer le personnel soignant pour qu'il sache bien gÃ©rer les personnes trans*~;
+			\item Ã  diffuser, tant aux Ã©tudiant-e-s qu'aux employÃ©-e-s, des informations sur l'identitÃ© et l'expression de genre et sur les politiques de l'UniversitÃ© visant les personnes trans*.
+		\end{enumerate}
+		\begin{instance}
+			AdoptÃ©: [AG-14/02/2014]
+		\end{instance}
+\end{enumerate}
 
+\section{Affaires internes}
+\begin{enumerate}
+	\item \marginnote{RÃ©troaction de mi-session} Que l'AÃ‰DIROUM s'assure de la tenue d'une rÃ©troaction de mi-session toutes les sessions d'automne et d'hiver.
+		\begin{instance}
+			AdoptÃ©: [AG-25/01/2011]
+		\end{instance}
 
-\subsection*{Délocalisation du campus}\sout{ Que l'AÉDIROUM s'oppose à toute
-autre expansion du campus de l'Université de Montréal contribuant à la
-course aux effectifs étudiants.}
-\begin{instance}
-  \emph{Adopté: [AG-25/01/2011], Abrogé: [AG-14/09/2011]}
-\end{instance}
+	\item \marginnote{Logiciels et formats} Que l'AÃ‰DIROUM prÃ©conise l'utilisation de logiciels libres et de formats ouverts.
+		\begin{instance}
+			AdoptÃ©: [AG-25/01/2011], ModifiÃ©: [AG-7/04/2011], ModifiÃ©: [AG-14/09/2011]
+		\end{instance}
 
-\subsection*{Transport en commun} Que l'AÉDIROUM appuie des démarches en
-vue d'avoir un tarif réduit pour tous les étudiants à temps plein.
-\begin{instance}
-  \emph{Adopté: [AG-07/04/2011], Modifié: [AG-14/09/2011]}
-\end{instance}
+	\item \marginnote{Politique linguistique} Que l'AÃ‰DIROUM s'assure que tous les cours et le matÃ©riel d'apprentissage soient disponibles en franÃ§ais au premier cycle.
+		\begin{instance}
+			AdoptÃ©: [AG-25/01/2011]
+		\end{instance}
 
-\subsection*{Accès à l'information}
-Que la FAÉCUM facilite l'accès à ses documents, notamment en
-permettant de rendre public ses documents d'intérêt général, dont ses
-règlements généraux et sa politique d'accès à l'information.
-\begin{instance}
-  \emph{Adopté: [AG-14/09/2011]}
-\end{instance}
+	\item Que l'AÃ‰DIROUM dÃ©fende le choix des Ã©tudiants en ce qui a trait au choix de la langue d'Ã©criture de leur thÃ¨se de doctorat ou de leur mÃ©moire de maÃ®trise.
+		\begin{instance}
+			AdoptÃ©: [AG-25/01/2011], ModifiÃ©: [AG-14/09/2011], ModifiÃ©: [AG-10/02/2012]
+		\end{instance}
 
+	\item \marginnote{IdentitÃ©} Que l'AÃ‰DIROUM reconnaisse l'identitÃ© de genre dÃ©clarÃ©e de tout-e-s ses membres dans le cadre de toutes ses activitÃ©s, peu importe leur statut lÃ©gal, administratif, chirurgical ou autre.
+		\begin{instance}
+			AdoptÃ©: [AG-14/02/2014]
+		\end{instance}
 
-\section*{Affaires internes}
-
-\subsection*{Rétroaction de mi-session} Que l'AÉDIROUM s'assure de la
-tenue d'une rétroaction de mi-session toutes les sessions d'automne et
-d'hiver.
-\begin{instance}
-  \emph{Adopté: [AG-25/01/2011]}
-\end{instance}
-
-
-\subsection*{Logiciels et formats} Que l'AÉDIROUM préconise
-l'utilisation de logiciels libres et de formats ouverts.
-\begin{instance}
-  \emph{Adopté: [AG-25/01/2011], Modifié: [AG-7/04/2011], Modifié:
-    [AG-14/09/2011]}
-\end{instance}
-
-
-\subsection*{Politique linguistique} Que l'AÉDIROUM s'assure que tous
-les cours et le matériel d'apprentissage soient disponibles en
-français au premier cycle.
-\begin{instance}
-  \emph{Adopté: [AG-25/01/2011]}
-\end{instance}
-
-Que l'AÉDIROUM défende le choix des étudiants en ce qui a trait au
-choix de la langue d'écriture de leur thèse de doctorat ou de leur
-mémoire de maîtrise.
-
-\begin{instance}
-  \emph{Adopté: [AG-25/01/2011], Modifié: [AG-14/09/2011], Modifié:
-    [AG-10/02/2012]}
-\end{instance}
+	\item Que l'AÃ‰DIROUM se positionne au niveau dÃ©partemental pour qu'on puisse utiliser son nom usuel sur les travaux et les examens.
+		\begin{instance}
+			AdoptÃ©: [AG-14/02/2014]
+		\end{instance}
+\end{enumerate}
 
 \end{document}
-


### PR DESCRIPTION
Avec la chance de re-créer le cahier, il y aura un nouveau format numéroté, et les vielles positions sont effacées.

Les positions adoptés en 2014 y sont ajoutés. Aucune nouvelle position y est prise. ~À voter en AG.~