### PR TITLE
Adjoint droit de vote

### DIFF
--- a/charte.tex
+++ b/charte.tex
@@ -159,6 +159,7 @@ Le conseil d'administration comprend, outre les cinq (5) membres du conseil exé
 \item Coordonnateur à la vie étudiante
 \item Représentant du café étudiant Math-Info
 \item Représentant des étudiants étrangers
+\item Tout adjoint à un poste de l'exécutif
 \end{itemize}
 
 \subsubsection{Représentant d'année ou de programme}\label{sec:representant-dannee-ou-de-programme}
@@ -181,7 +182,7 @@ La tâche du représentant du café étudiant est définie dans la charte du caf
 
 \subsubsection{Cumul de postes}\label{sec:cumul-de-postes}
 
-Sans aller à l'encontre de l'\article{sec:composition-du-conseil-executif}, il peut y avoir, au sein du conseil d'administration, cumul de postes par une même personne.
+Sans aller à l'encontre de l'\article{sec:composition-du-conseil-executif}, il peut y avoir, au sein du conseil d'administration, cumul de postes par une même personne. Au sein de l'\article{sec:quorum-et-participation}, le cumul de poste n'entraine pas de voix supplémentaire lors de vote en CA
 
 \subsection{Autres membres du comité du café étudiant}\label{sec:autres-membres-du-comite-du-cafe-etudiant}
 
@@ -198,8 +199,6 @@ Un adjoint ne peut pas occuper de poste sur le conseil executif ou d'administrat
 Un adjoint accompage le délégué aux instances de la FAÉCUM relatives au poste dont il est adjoint.
 
 La responsabilité de la formation d'un adjoint et son inclusion dans les dossiers relatifs au poste reviennent au titulaire du poste en question.
-
-Pour les fins de l'\article{sec:mandat} de la présente charte, les adjoints sont réputés membres du conseil d'administration.
 
 \subsubsection{Personne de confiance}\label{sec:personne-de-confiance}
 La personne de confiance peut être élue en assemblée générale. Elle possède les clés du local de l'association étudiante pour pouvoir y donner accès lorsque les membres du conseil exécutif ne sont pas sur les lieux.

--- a/charte.tex
+++ b/charte.tex
@@ -182,7 +182,7 @@ La tâche du représentant du café étudiant est définie dans la charte du caf
 
 \subsubsection{Cumul de postes}\label{sec:cumul-de-postes}
 
-Sans aller à l'encontre de l'\article{sec:composition-du-conseil-executif}, il peut y avoir, au sein du conseil d'administration, cumul de postes par une même personne. Au sein de l'\article{sec:quorum-et-participation}, le cumul de poste n'entraine pas de voix supplémentaire lors de vote en CA
+Sans aller à l'encontre de l'\article{sec:composition-du-conseil-executif}, il peut y avoir, au sein du conseil d'administration, cumul de postes par une même personne. Au sein de l'\article{sec:quorum-et-participation}, le cumul de poste n'entraine pas de voix supplémentaire lors de vote en CA.
 
 \subsection{Autres membres du comité du café étudiant}\label{sec:autres-membres-du-comite-du-cafe-etudiant}
 

--- a/charte.tex
+++ b/charte.tex
@@ -194,7 +194,7 @@ Un adjoint peut être élu en assemblée générale pour chaque poste du conseil
 
 Est admissible à un poste d'adjoint tout membre en règle de l'AÉDIROUM n'occupant pas déjà un poste d'adjoint.
 
-Un adjoint ne peut pas occuper de poste sur le conseil executif ou d'administration de l'AÉDIROUM.
+Un adjoint d'un poste du conseil exécutif ne peut pas occuper d'autre poste sur le conseil executif de l'AÉDIROUM.
 
 Un adjoint accompage le délégué aux instances de la FAÉCUM relatives au poste dont il est adjoint.
 
@@ -265,7 +265,7 @@ Aucun des membres du conseil d'administration n'est rémunéré pour l'exercice 
 Tout membre du conseil exécutif, ses héritiers et ayants droit seront tenus, au besoin et à toute époque, à même les fonds de l'AÉDIROUM, indemnes et à couvert~:
 \begin{itemize}
 \item de tous frais, charges et dépenses quelconques que ce membre subit ou supporte au cours ou à l'occasion d'une action, poursuite ou procédure intenté contre lui, à l'égard ou en raison d'actes faits ou choses accomplies ou permises par lui dans l'exercice ou pour l'exécution de ses fonctions, et
-\item de tous autres frais, charges et dépenses qu'il supporte ou subit au cours ou à l'occation des affaires de l'AÉDIROUM ou relativement à ces affaires, exceptés ceux qui résultent de sa propre néglicence ou de son omission volontaire.
+\item de tous autres frais, charges et dépenses qu'il supporte ou subit au cours ou à l'occasion des affaires de l'AÉDIROUM ou relativement à ces affaires, exceptés ceux qui résultent de sa propre néglicence ou de son omission volontaire.
 \end{itemize}
 
 \subsubsection{Procédure de preuve}\label{sec:procedure-de-preuve}


### PR DESCRIPTION
La charte n'est pas clair sur le cumul de vote lors des CA. Cette PR clarifie la règle : il n'y a plus de cumul. Cette décision a été prise principalement car permettre le cumul entraine des complications lors du comptage des votes sérrés. De plus, il est difficile d'être impartial et "voté pour chaque poste qu'on représente" plutot que choisir sa propre opinion. Finalement, cette PR premet aux adjoints de voté (ils font maintenant partie du CA). Cette décision a été prise car toute personne qui participe au débat devrait avoir un droit de vote, adjoint ou pas. Cela encourage la discussion. 