### PR TITLE
Créer positions sur la politique linguistique

### DIFF
--- a/positions.tex
+++ b/positions.tex
@@ -125,9 +125,6 @@ Ce document a été créé à la session d'hiver 2011 par l'exécutif en place a
 
 	\item Que l'AÉDIROUM reconnait l'importance de l'Université de Montréal dans une contexte de la préservation de la langue française.
 	\item Que l'AÉDIROUM demande que les modalités linguistiques des cours soit clairement affichés dans les répertoires et plans de cours.
-	\item Que l'AÉDIROUM accepte que des cours de première cycle soient bilingues sans préférence à l'anglais.
-	\item Que l'AÉDIROUM accepte que des cours des cycles supérieurs soient uniquement en anglais.
-	\item Que l'AÉDIROUM propose que des étudiants puissent être rénumérés dans un role de traducteur pour les cours sensés bilingues.
 
 	\item \marginnote{Identité} Que l'AÉDIROUM reconnaisse l'identité de genre déclarée de tout-e-s ses membres dans le cadre de toutes ses activités, peu importe leur statut légal, administratif, chirurgical ou autre.
 		\begin{instance}

--- a/positions.tex
+++ b/positions.tex
@@ -123,6 +123,12 @@ Ce document a été créé à la session d'hiver 2011 par l'exécutif en place a
 			Adopté: [AG-25/01/2011], Modifié: [AG-14/09/2011], Modifié: [AG-10/02/2012]
 		\end{instance}
 
+	\item Que l'AÉDIROUM reconnait l'importance de l'Université de Montréal dans une contexte de la préservation de la langue française.
+	\item Que l'AÉDIROUM demande que les modalités linguistiques des cours soit clairement affichés dans les répertoires et plans de cours.
+	\item Que l'AÉDIROUM accepte que des cours de première cycle soient bilingues sans préférence à l'anglais.
+	\item Que l'AÉDIROUM accepte que des cours des cycles supérieurs soient uniquement en anglais.
+	\item Que l'AÉDIROUM propose que des étudiants puissent être rénumérés dans un role de traducteur pour les cours sensés bilingues.
+
 	\item \marginnote{Identité} Que l'AÉDIROUM reconnaisse l'identité de genre déclarée de tout-e-s ses membres dans le cadre de toutes ses activités, peu importe leur statut légal, administratif, chirurgical ou autre.
 		\begin{instance}
 			Adopté: [AG-14/02/2014]


### PR DESCRIPTION
Afin d'être plus constant avec les attentes de la représentation des étudiants face à des problèmes liés à la langue, on soumet des positions pour mettre en valeur la langue française à l'université et la clarté des indications linguistiques.