### PR TITLE
Remplacer 'étudiant' par 'étudiant·e'

### DIFF
--- a/aediroum.cls
+++ b/aediroum.cls
@@ -7,6 +7,9 @@
 \RequirePackage[T1]{fontenc}
 \RequirePackage[french]{babel}
 
+\RequirePackage{newunicodechar}
+\newunicodechar{·}{\ifmmode\cdot\else$\cdot$\fi}
+
 \RequirePackage{moresize}
 \RequirePackage{parskip}
 \RequirePackage{marginnote}

--- a/charte.tex
+++ b/charte.tex
@@ -158,7 +158,7 @@ Le conseil d'administration comprend, outre les cinq (5) membres du conseil exé
 \item Représentant du doctorat en informatique
 \item Coordonnateur à la vie étudiante
 \item Représentant du café étudiant Math-Info
-\item Représentant des étudiants internationaux
+\item Représentant des étudiant·e·s internationaux
 \item Tout adjoint à un poste de l'exécutif
 \end{itemize}
 
@@ -166,9 +166,9 @@ Le conseil d'administration comprend, outre les cinq (5) membres du conseil exé
 
 Les représentants d'année ou de programme assurent la communication entre l'AÉDIROUM et ses membres. Ils sont responsables de contacter les membres qu'ils représentent au nom de l'AÉDIROUM et de rediriger les requêtes des membres qu'ils représentent à l'officier approprié. Ils doivent rejoindre et mobiliser les membres pour prendre part aux actions de l'AÉDIROUM. Il est à noter que les représentants d'année au baccalauréat doivent avoir au moins un cours de l'année (en informatique) qu'ils représentent lors de leur mandat; ceci est déterminé par le sigle. Les représentants des autres programmes doivent appartenir au programme qu'ils représentent.
 
-\subsubsection{Représentant des étudiants internationaux}\label{sec:representant-des-etudiants-internationaux}
+\subsubsection{Représentant des étudiant·e·s internationaux}\label{sec:representant-des-etudiants-internationaux}
 
-Le représentant des étudiants internationaux assure la communication entre l'AÉDIROUM et ses membres qui ont un statut d'étudiant international. Il est responsable de contacter les membres qu'il représente au nom de l'AÉDIROUM et de rediriger les requêtes des membres qu'il représente à l'officier approprié. Il doit rediriger et mobiliser les membres pour prendre part aux actions de l'AÉDIROUM.
+Le représentant des étudiant·e·s internationaux assure la communication entre l'AÉDIROUM et ses membres qui ont un statut d'étudiant·e international·e. Il est responsable de contacter les membres qu'il représente au nom de l'AÉDIROUM et de rediriger les requêtes des membres qu'il représente à l'officier approprié. Il doit rediriger et mobiliser les membres pour prendre part aux actions de l'AÉDIROUM.
 
 \subsubsection{Coordonnateur à la vie étudiante}\label{sec:coordonnateur-a-la-vie-etudiante}
 
@@ -186,7 +186,7 @@ Sans aller à l'encontre de l'\article{sec:composition-du-conseil-executif}, il 
 
 \subsection{Autres membres du comité du café étudiant}\label{sec:autres-membres-du-comite-du-cafe-etudiant}
 
-Seront élus deux autres membres du comité du café étudiant, qui ne seront pas membres du conseil d'administration. L'un de ces postes sera ouvert en priorité à un étudiant de première année afin de favoriser le bon roulement des membres du comité du café. C'est ce poste pour lequel l'élection se fera en automne. Parmi le représentant du café étudiant et les deux membres élus du comité, deux seront signataires pour le compte du café étudiant. Pour les fins de l'\article{sec:mandat} de la présente charte, les membres du comité du café étudiant sont réputés membres du conseil d'administration.
+Seront élus deux autres membres du comité du café étudiant, qui ne seront pas membres du conseil d'administration. L'un de ces postes sera ouvert en priorité à un·e étudiant·e de première année afin de favoriser le bon roulement des membres du comité du café. C'est ce poste pour lequel l'élection se fera en automne. Parmi le représentant du café étudiant et les deux membres élus du comité, deux seront signataires pour le compte du café étudiant. Pour les fins de l'\article{sec:mandat} de la présente charte, les membres du comité du café étudiant sont réputés membres du conseil d'administration.
 
 \subsection{Adjoints}\label{sec:adjoints}
 


### PR DESCRIPTION
Comme adopté à l'AG hier. Vérifiez que tout est correct et rien n'est manqué.

On ne peut pas changer le nom si facilement, mais peut-être pour la prochaine fois on peut aller all-in pour l'écriture avec les noms des postes.